### PR TITLE
Bugfix for working on Safari

### DIFF
--- a/src/base64-arraybuffer.js
+++ b/src/base64-arraybuffer.js
@@ -15,7 +15,8 @@ for (let i = 0; i < chars.length; i++) {
 }
 
 export const encode = function (arraybuffer, byteOffset, length) {
-    const bytes = new Uint8Array(arraybuffer, byteOffset, length),
+    if (length == null) length = arraybuffer.byteLength; // Needed for Safari
+    const bytes = new Uint8Array(arraybuffer, byteOffset || 0 /* Needed for Safari */, length),
         len = bytes.length;
     let base64 = '';
 


### PR DESCRIPTION
In Safari, the Uint8Array constructor behaves differently than in other browsers.
```js
const a = new Uint8Array(buf, undefined, undefined);
// the result "a" will have zero length no matter buf.byteLength.
```